### PR TITLE
Security issue : must update "underscore" dependency to version 1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "babel-runtime": "6.x.x",
-    "underscore": "1.9.1"
+    "underscore": "1.12.1"
   }
 }


### PR DESCRIPTION
This lib has "underscore@1.9.1" as a dependency. This version is known to have an high security issue (see https://npmjs.com/advisories/1674 )
A simple solution is to update to underscore@1.12.1